### PR TITLE
Monday - Redis cache invalidation

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+  semi: false,
+  trailingComma: "all",
+  singleQuote: true,
+  printWidth: 80,
+  tabWidth: 2
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -187,7 +187,7 @@ export class MondayRedisService extends BaseConnector {
             columnTitle,
             this.serialize(value, columnTitle),
           )
-          await this.destageChanges(columnTitle)
+          await this.destageChanges(itemId)
         }
       },
     )

--- a/src/index.ts
+++ b/src/index.ts
@@ -179,24 +179,25 @@ export class MondayRedisService extends BaseConnector {
       async (event) => {
         const { boardId, itemId, columnTitle, value: { value } } = event
         if (this.boardId === parseInt(boardId, 10)) {
-          const redisCurrentValue = await this.redis.hget(
+          // const redisCurrentValue = await this.redis.hget(
+          //   this.keyForItem(itemId),
+          //   columnTitle,
+          // )
+          // const redisCurrentValueDeserialized = this.deserialize(redisCurrentValue, columnTitle)
+
+          // if (redisCurrentValueDeserialized !== value) {
+          this.app.getLogger().info(`Monday event received - Redis/Monday values differ for itemId ${itemId} (title: ${columnTitle})`)
+          await this.redis.hset(
             this.keyForItem(itemId),
             columnTitle,
+            this.serialize(value, columnTitle),
           )
-          const redisCurrentValueDeserialized = this.deserialize(redisCurrentValue, columnTitle)
-
-          if (redisCurrentValueDeserialized !== value) {
-            this.app.getLogger().info(`Monday event received - Redis/Monday values differ for itemId ${itemId} (title: ${columnTitle})`)
-            await this.redis.hset(
-              this.keyForItem(itemId),
-              columnTitle,
-              this.serialize(value, columnTitle),
-            )
-            const currentChanges = await this.redis.get(this.changesKey)
-            const changeKey = this.getChangeKey(itemId, columnTitle)
-            await this.redis.set(this.changesKey, currentChanges.replace(changeKey, ''))
-            this.app.getLogger().info(`Redis - value updated (previous: ${redisCurrentValueDeserialized}, new: ${value}) for itemId ${itemId} (title: ${columnTitle})`)
-          }
+          await this.destageChanges()
+            // const currentChanges = await this.redis.get(this.changesKey)
+            // const changeKey = this.getChangeKey(itemId, columnTitle)
+            // await this.redis.set(this.changesKey, currentChanges.replace(changeKey, ''))
+            // this.app.getLogger().info(`Redis - value updated (previous: ${redisCurrentValueDeserialized}, new: ${value}) for itemId ${itemId} (title: ${columnTitle})`)
+          // }
         }
       },
     )

--- a/src/index.ts
+++ b/src/index.ts
@@ -143,7 +143,6 @@ export class MondayRedisService extends BaseConnector {
     update: Promise<any>,
   ) {
     const change = this.getChangeKey(itemId, title)
-    console.log(change)
     return Promise.all([update, this.redis.append(this.changesKey, change)])
   }
 
@@ -194,11 +193,8 @@ export class MondayRedisService extends BaseConnector {
               this.serialize(value, columnTitle),
             )
             const currentChanges = await this.redis.get(this.changesKey)
-            console.log('currentChanges', currentChanges)
             const changeKey = this.getChangeKey(itemId, columnTitle)
-            console.log('changeKey',changeKey)
             await this.redis.set(this.changesKey, currentChanges.replace(changeKey, ''))
-            console.log('this.changesKey',currentChanges.replace(changeKey, ''))
             this.app.getLogger().info(`Redis - value updated (previous: ${redisCurrentValueDeserialized}, new: ${value}) for itemId ${itemId} (title: ${columnTitle})`)
           }
         }


### PR DESCRIPTION
Listen to Monday event, when a value is different than the one is Redis, we invalidate it.
Next update for that value will resync with latest value in Monday.
Optimisation: make sure each update from Reshuffle doesn't cause the webhook to be invoked and so the value being invalidated